### PR TITLE
Removing conflicting parameters where auth_method != clientpostsecret in the OIDC flow.

### DIFF
--- a/adapter/authserver/authserver.go
+++ b/adapter/authserver/authserver.go
@@ -122,9 +122,8 @@ func (s *RemoteService) UserInfoEndpoint() string {
 // GetTokens performs a request to the token endpoint
 func (s *RemoteService) GetTokens(authnMethod string, clientID string, clientSecret string, authorizationCode string, redirectURI string, refreshToken string) (*TokenResponse, error) {
 	_ = s.initialize()
-	form := url.Values{
-		"client_id": {clientID},
-	}
+	form := url.Values{}
+
 	if refreshToken != "" {
 		form.Add("grant_type", "refresh_token")
 		form.Add("refresh_token", refreshToken)


### PR DESCRIPTION
Removing client_id from the body of requests where auth_method != clientpostsecret.

When the auth method == clientpostbasic, client_id should not be passed as an argument within the post body. Some identity providers are unable to process requests where multiple client_id's are specified. In this configuration, any requests that are not `clientpostsecret` would also recieve the `client_id` parameter passed into the request body. This condition is already passed in line 137.