### PR TITLE
making it compatible with k8s >1.16

### DIFF
--- a/helm/appidentityandaccessadapter/templates/deployment.yaml
+++ b/helm/appidentityandaccessadapter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dpl-{{ .Values.appName }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ .Values.appName }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.appName }} 
   template:
     metadata:
       labels:


### PR DESCRIPTION
apiVersion extensions/v1beta1 is deprecated ib K8s 1.16 and the selector field is now mandatory.