### PR TITLE
Customizable scopes to request using OidcConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Depending on whether you're protecting frontend or backend applications, create 
     | `clientSecretRef` | object | no | A reference secret that is used to authenticate the client. This can be used in place of the `clientSecret`. |
     | `clientSecretRef.name` | string |yes | The name of the Kubernetes Secret that contains the `clientSecret`. |
     | `clientSecretRef.key` | string | yes | The field within the Kubernetes Secret that contains the `clientSecret`. |
+    | `scopes` | array[string] | no | The scopes to request (`openid profile email` by default). |
 
 
 * For backend applications: The OAuth 2.0 Bearer token spec defines a pattern for protecting APIs by using [JSON Web Tokens (JWTs)](https://tools.ietf.org/html/rfc7519.html). Using the following configuration as an example, define a `JwtConfig` CRD that contains the public key resource, which is used to validate token signatures.

--- a/adapter/client/client.go
+++ b/adapter/client/client.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"errors"
+	"strings"
 
 	"go.uber.org/zap"
 
 	"github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/authserver"
-	"github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/pkg/apis/policies/v1"
+	v1 "github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/pkg/apis/policies/v1"
 )
 
 // Client encapsulates an authn/z client object
@@ -14,6 +15,7 @@ type Client interface {
 	Name() string
 	ID() string
 	Secret() string
+	Scope() string
 	AuthorizationServer() authserver.AuthorizationServerService
 	ExchangeGrantCode(code string, redirectURI string) (*authserver.TokenResponse, error)
 	RefreshToken(refreshToken string) (*authserver.TokenResponse, error)
@@ -34,6 +36,13 @@ func (c *remoteClient) ID() string {
 
 func (c *remoteClient) Secret() string {
 	return c.ClientSecret
+}
+
+func (c *remoteClient) Scope() string {
+	if len(c.Scopes) == 0 {
+		return "openid profile email"
+	}
+	return strings.Join(c.Scopes, " ")
 }
 
 func (c *remoteClient) AuthorizationServer() authserver.AuthorizationServerService {

--- a/adapter/pkg/apis/policies/v1/oidc_config.go
+++ b/adapter/pkg/apis/policies/v1/oidc_config.go
@@ -17,17 +17,18 @@ type OidcConfig struct {
 
 // OidcConfigSpec is the spec for a OidcConfig resource
 type OidcConfigSpec struct {
-	ClientName       string
-	AuthMethod       string `json:"authMethod"`
-	ClientID         string `json:"clientId"`
-	DiscoveryURL     string `json:"discoveryUrl"`
-	ClientSecret     string `json:"clientSecret"`
+	ClientName      string
+	AuthMethod      string          `json:"authMethod"`
+	ClientID        string          `json:"clientId"`
+	DiscoveryURL    string          `json:"discoveryUrl"`
+	ClientSecret    string          `json:"clientSecret"`
 	ClientSecretRef ClientSecretRef `json:"clientSecretRef"`
+	Scopes          []string        `json:"scopes"`
 }
 
 type ClientSecretRef struct {
-	Name	string `json:"name"`
-	Key		string `json:"key"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/adapter/strategy/web/utils.go
+++ b/adapter/strategy/web/utils.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/client"
-	"github.com/ibm-cloud-security/app-identity-and-access-adapter/config/template"
+	authnz "github.com/ibm-cloud-security/app-identity-and-access-adapter/config/template"
 )
 
 const (
@@ -60,7 +60,7 @@ func generateAuthorizationURL(c client.Client, redirectURI string, state string)
 		"client_id":     {c.ID()},
 		"response_type": {"code"},
 		"redirect_uri":  {redirectURI},
-		"scope":         {"openid profile email"},
+		"scope":         {c.Scope()},
 		"state":         {state},
 	}
 

--- a/bin/docker_build_tag_push.sh
+++ b/bin/docker_build_tag_push.sh
@@ -58,8 +58,8 @@ function buildAndDeploy() {
 }
 
 
-IMAGE_REGISTRY_NAMESPACE=ibmcloudsecurity
-APP_NAME=app-identity-and-access-adapter
+IMAGE_REGISTRY_NAMESPACE=${IMAGE_REGISTRY_NAMESPACE:-ibmcloudsecurity}
+APP_NAME=${APP_NAME:-app-identity-and-access-adapter}
 TAG=$(buildTag $1)
 IMAGE_TAG=${IMAGE_REGISTRY_NAMESPACE}/${APP_NAME}:${TAG}
 sourceDir="$(dirname "${BASH_SOURCE[0]}")"

--- a/tests/fake/client.go
+++ b/tests/fake/client.go
@@ -1,6 +1,8 @@
 package fake
 
-import "github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/authserver"
+import (
+	"github.com/ibm-cloud-security/app-identity-and-access-adapter/adapter/authserver"
+)
 
 type TokenResponse struct {
 	Res *authserver.TokenResponse
@@ -13,6 +15,7 @@ type Client struct {
 	ClientName    string
 	ClientID      string
 	ClientSecret  string
+	Scopes        []string
 }
 
 func NewClient(tokenResponse *TokenResponse) *Client {
@@ -35,6 +38,10 @@ func (m *Client) ID() string {
 
 func (m *Client) Secret() string {
 	return m.ClientSecret
+}
+
+func (m *Client) Scope() string {
+	return "openid profile email"
 }
 
 func (m *Client) AuthorizationServer() authserver.AuthorizationServerService {


### PR DESCRIPTION
All OpenID providers must support `openid` scope, although various OpenID providers support various additional scopes. 

The original implementation of this adapter had the hard-codded list of `openid profile email` scopes.

This pull request makes scopes optionally configurable in the OidcConfig CRD:

```
apiVersion: "security.cloud.ibm.com/v1"
kind:       OidcConfig
metadata:
  name:      oidc-provider-config
  namespace: default
spec:
  authMethod:   client_secret_basic
  discoveryUrl: https://myopenid.com/discovery
  clientId:     myclientid
  clientSecret: myclientsecret
  scopes:
    - openid 
    - profile
    - email
    - groups
```

Additionally, the first commit makes `IMAGE_REGISTRY_NAMESPACE` and `APP_NAME` over-writable in the `docker_build_tag_push.sh` script and has no effect unless overwritten by setting these variables before running the script.