### PR TITLE
Fix path join issue for the callback url

### DIFF
--- a/adapter/strategy/web/utils.go
+++ b/adapter/strategy/web/utils.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 	"unsafe"
 
@@ -72,7 +73,7 @@ func generateAuthorizationURL(c client.Client, redirectURI string, state string)
 
 // buildRequestURL constructs the original url from the request object
 func buildRequestURL(action *authnz.RequestMsg) string {
-	return action.Scheme + "://" + action.Host + action.Path
+	return action.Scheme + "://" + path.Join(action.Host, action.Path)
 }
 
 // buildTokenCookieName constructs the cookie name

--- a/adapter/strategy/web/utils_test.go
+++ b/adapter/strategy/web/utils_test.go
@@ -55,7 +55,7 @@ func TestGenerateAuthorizationURL(t *testing.T) {
 func TestBuildRequestURL(t *testing.T) {
 	inp := &authnz.RequestMsg{
 		Scheme: "https",
-		Host:   "me.com",
+		Host:   "me.com/",
 		Path:   "/hello world",
 	}
 	assert.Equal(t, "https://me.com/hello world", buildRequestURL(inp))


### PR DESCRIPTION
Callback URL includes an additional slash when the the path is '/' for an OIDC policy. This ends up with producing an invalid redirect url. One such example is this following url: `https://example.com//oidc/callback`

This PR strips that additional slash by using path.Join instead of a straight concatenation. 