### PR TITLE
Remove Control Character in jwt-config Helm Template

### DIFF
--- a/helm/appidentityandaccessadapter/templates/jwt-config.yaml
+++ b/helm/appidentityandaccessadapter/templates/jwt-config.yaml
@@ -1,1 +1,25 @@
-apiVersion: apiextensions.k8s.io/v1beta1kind:       CustomResourceDefinitionmetadata:    name: jwtconfigs.security.cloud.ibm.comspec:    group: security.cloud.ibm.com    versions:    - name:    v1      served:  true      storage: true    scope: Namespaced    names:        plural:   jwtconfigs        singular: jwtconfig        kind:     JwtConfig    validation:        openAPIV3Schema:            properties:                spec:                    required:                    - jwksUrl                    properties:                        jwksUrl:                            type:    string                            pattern: '^(?:http(s)?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$'
+apiVersion: apiextensions.k8s.io/v1beta1
+kind:       CustomResourceDefinition
+metadata:
+    name: jwtconfigs.security.cloud.ibm.com
+spec:
+    group: security.cloud.ibm.com
+    versions:
+    - name:    v1
+      served:  true
+      storage: true
+    scope: Namespaced
+    names:
+        plural:   jwtconfigs
+        singular: jwtconfig
+        kind:     JwtConfig
+    validation:
+        openAPIV3Schema:
+            properties:
+                spec:
+                    required:
+                    - jwksUrl
+                    properties:
+                        jwksUrl:
+                            type:    string
+                            pattern: '^(?:http(s)?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$'


### PR DESCRIPTION
Removed the `^M` characters the `jwt-config.yaml` via VIM following https://stackoverflow.com/questions/3852868/how-to-make-vim-show-m-and-substitute-it