### PR TITLE
Allow to use a config object from a particular namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ spec:
 | Policy Object  | Type | Required | Description   |
 |----------------|:----:|:--------:| :-----------: |
 | `policyType` | enum | yes | The type of OIDC policy. Options include: `jwt` or `oidc`. |
-| `config` | string | yes | The name of the provider config that you want to use. |
+| `config` | string | yes | The name of the provider config that you want to use. By default is looking for a config object in the same namespace where the target service is located. To use config from a particular namespace - specify it in format `namespace/config_name`  |
 | `redirectUri` | string | no | The url you want the user to be redirected after successful authentication, default: the original request url. |
 | `rules` | array[Rule] | no | The set of rules the you want to use for token validation. |
 

--- a/adapter/policy/engine/engine.go
+++ b/adapter/policy/engine/engine.go
@@ -110,6 +110,10 @@ func (m *engine) getPolicies(endpoints []policy.Endpoint) ([]Action, error) {
 				}
 
 				configName := ep.Service.Namespace + "/" + p.Config
+
+				if strings.Contains(p.Config, "/") {
+					configName = p.Config
+				}
 				zap.L().Debug("Checking for configuration", zap.String("name", configName), zap.String("type", action.PolicyType))
 
 				switch action.Type {

--- a/adapter/strategy/web/web.go
+++ b/adapter/strategy/web/web.go
@@ -3,6 +3,7 @@ package webstrategy
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -289,7 +290,8 @@ func (w *WebStrategy) handleAuthorizationCodeCallback(code interface{}, request 
 	redirectURI := buildRequestURL(request)
 
 	// Exchange authorization grant code for tokens
-	response, err := action.Client.ExchangeGrantCode(code.(string), redirectURI)
+	unescapedCode, err := url.QueryUnescape(code.(string))
+	response, err := action.Client.ExchangeGrantCode(unescapedCode, redirectURI)
 	if err != nil {
 		zap.L().Info("OIDC callback: Could not retrieve tokens", zap.Error(err), zap.String("client_name", action.Client.Name()))
 		return w.handleErrorCallback(err)


### PR DESCRIPTION
This change allows using `oidcconfig` objects located in namespaces that are different from one where the service is located.
The default behavior is preserved. Docs updated.