### PR TITLE
Bug fix: Avoid setting KeySet with an empty JWKS URL

### DIFF
--- a/adapter/policy/handler/crdeventhandler/add_event.go
+++ b/adapter/policy/handler/crdeventhandler/add_event.go
@@ -17,18 +17,18 @@ type AddUpdateEventHandler interface {
 }
 
 type JwtConfigAddEventHandler struct {
-	Obj *v1.JwtConfig
+	Obj   *v1.JwtConfig
 	Store storepolicy.PolicyStore
 }
 
 type OidcConfigAddEventHandler struct {
-	Obj *v1.OidcConfig
+	Obj        *v1.OidcConfig
 	KubeClient kubernetes.Interface
-	Store storepolicy.PolicyStore
+	Store      storepolicy.PolicyStore
 }
 
 type PolicyAddEventHandler struct {
-	Obj *v1.Policy
+	Obj   *v1.Policy
 	Store storepolicy.PolicyStore
 }
 
@@ -46,8 +46,11 @@ func (e *OidcConfigAddEventHandler) HandleAddUpdateEvent() {
 		e.Obj.Spec.AuthMethod = "client_secret_basic"
 	}
 	authorizationServer := authserver.New(e.Obj.Spec.DiscoveryURL)
-	keySets := keyset.New(authorizationServer.JwksEndpoint(), nil)
-	authorizationServer.SetKeySet(keySets)
+	jwksURL := authorizationServer.JwksEndpoint()
+	if jwksURL != "" {
+		keySets := keyset.New(authorizationServer.JwksEndpoint(), nil)
+		authorizationServer.SetKeySet(keySets)
+	}
 	e.Obj.Spec.ClientSecret = GetClientSecret(e.Obj, e.KubeClient)
 	// Create and store OIDC Client
 	oidcClient := client.New(e.Obj.Spec, authorizationServer)
@@ -57,11 +60,11 @@ func (e *OidcConfigAddEventHandler) HandleAddUpdateEvent() {
 
 func (e *PolicyAddEventHandler) HandleAddUpdateEvent() {
 	zap.L().Debug("Create/Update Policy", zap.String("ID", string(e.Obj.ObjectMeta.UID)), zap.String("name", e.Obj.ObjectMeta.Name), zap.String("namespace", e.Obj.ObjectMeta.Namespace))
-	mappingId := e.Obj.ObjectMeta.Namespace + "/" +e.Obj.ObjectMeta.Name
+	mappingId := e.Obj.ObjectMeta.Namespace + "/" + e.Obj.ObjectMeta.Name
 	parsedPolicies := ParseTarget(e.Obj.Spec.Target, e.Obj.ObjectMeta.Namespace)
 	for _, policies := range parsedPolicies {
 		zap.S().Debug("Adding policy for endpoint", policies.Endpoint)
-		e.Store.SetPolicies(policies.Endpoint, policy.RoutePolicy{ PolicyReference: mappingId, Actions: policies.Actions})
+		e.Store.SetPolicies(policies.Endpoint, policy.RoutePolicy{PolicyReference: mappingId, Actions: policies.Actions})
 	}
 	e.Store.AddPolicyMapping(mappingId, parsedPolicies)
 	zap.L().Info("Policy created/updated", zap.String("ID", string(e.Obj.ObjectMeta.UID)))


### PR DESCRIPTION
Attempt to always use the JWKS URL from the discovery if available.

This should prevent the following error due to empty JWKS URL:
"Failed to retrieve public keys", "url":"","error":"Get : unsupported protocol scheme \"\""

That error means JWKS URL in the KeySet object was an empty string.

It could easily happen if discovery endpoint failed during add/update of OidcConfig CRD. Even if there was a valid KeySet with a valid JWKS URL before, discovery endpoint failure during add/update would overwrite this valid KeySet with a new KeySet containing an empty string for JWKS URL.

Note that add/update operation also happens on adapter startup or after Kubernetes API starts being available after a temporary downtime so this bad overwrite can happen any time discovery endpoint is unable to respond at the time add/update handler for OidcConfig is called. 