### PR TITLE
Do Not Append Default OIDC Rule if User Specifies Rules

### DIFF
--- a/adapter/policy/engine/engine.go
+++ b/adapter/policy/engine/engine.go
@@ -77,7 +77,7 @@ func (m *engine) Evaluate(target *authnz.TargetMsg) (*Action, error) {
 		if p.Rules == nil {
 			policies[i].Rules = createDefaultRules(p)
 		} else {
-			policies[i].Rules = append(p.Rules, createDefaultRules(p)...)
+			policies[i].Rules = p.Rules
 		}
 	}
 
@@ -150,8 +150,8 @@ func createDefaultRules(action Action) []v1.Rule {
 	case policy.OIDC:
 		return []v1.Rule{
 			{
-				Claim: aud,
-				Match: "ANY",
+				Claim:  aud,
+				Match:  "ANY",
 				Values: []string{action.Client.ID()},
 			},
 		}


### PR DESCRIPTION
Right now `rules` are broken for an OIDC policy if the `aud` claim doesn't have the `client_id` (the default rule) because the default rule is always appended to the user-defined rules. Okta and I imagine other OIDC providers, only support a single `aud` claim, so if it is not set to a specific `client_id` this rule always fails. 

Let me know if this is intentional.

cc @k3a 