### PR TITLE
fix: description cannot be nil for new versions of helm 

### DIFF
--- a/helm/appidentityandaccessadapter/templates/ibmcloudappid.yaml
+++ b/helm/appidentityandaccessadapter/templates/ibmcloudappid.yaml
@@ -6,7 +6,7 @@ metadata:
   name: appidentityandaccessadapter
   namespace: istio-system
 spec:
-  description: 
+  description: ""
   session_based: false
   templates:
   - authnz


### PR DESCRIPTION
**RCA**:

In the file `helm/appidentityandaccessadapter/templates/ibmcloudappid.yaml` in [the line 9](https://github.com/ibm-cloud-security/app-identity-and-access-adapter/blob/e539a9fdb8321ee736a417abb742ea13678a3e6b/helm/appidentityandaccessadapter/templates/ibmcloudappid.yaml#L9) `description` is set to `nil` causing the problem when generating the templates.

How get to issue:

1. Generate templates and split them per resource:
```
helm install ./helm/appidentityandaccessadapter --generate-name

csplit -f resource_ -z .out /---/ '{*}'
```
2. Apply each file independently, when reaching resource with the name `The resource with the name `resource_06` will fail with the following prompt

```
$ kubectl apply -f adapter_06

error: error validating "adapter_06": error validating data: unknown object type "nil" in adapter.spec.description; if you choose to ignore these errors, turn validation off with --validate=false
```

3. While turning validation off would help, as the message says, the issue can be solved as well changing the `description` from `nil` to `empty string ("")`, i.e.:

from:
```
---
...
apiVersion: "config.istio.io/v1alpha2"
kind: adapter
metadata:
  name: appidentityandaccessadapter
  namespace: istio-system
spec:
  description: 
...
```

to:
```

...
apiVersion: "config.istio.io/v1alpha2"
kind: adapter
metadata:
  name: appidentityandaccessadapter
  namespace: istio-system
spec:
  description: ""   # <---- Empty String
...
```

**Solution:**

Replace the `description` in the template `helm/appidentityandaccessadapter/templates/ibmcloudappid.yaml` from `nil` to `""` to have a clean helm installation.

fixes #68